### PR TITLE
STALE-BRANCH-BACKUP - Fix pagination header error with marshmallow 2

### DIFF
--- a/flask_smorest/pagination.py
+++ b/flask_smorest/pagination.py
@@ -260,7 +260,10 @@ class PaginationMixin:
                     page_header['previous_page'] = page - 1
                 if page < last_page:
                     page_header['next_page'] = page + 1
-        return PaginationHeaderSchema().dumps(page_header)
+        header = PaginationHeaderSchema().dumps(page_header)
+        if MARSHMALLOW_VERSION_MAJOR < 3:
+            header = header.data
+        return header
 
     @staticmethod
     def _prepare_pagination_doc(doc, doc_info, **kwargs):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -146,6 +146,8 @@ class TestPagination():
                 '{"total": 2, "total_pages": 1, '
                 '"first_page": 1, "last_page": 1, "page": 1}'
             )
+            # Also check there is only one pagination header
+            assert len(response.headers.getlist(header_name)) == 1
 
     def test_pagination_header_documentation(self, app):
         """Test pagination header is documented"""


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 